### PR TITLE
feat: enable metrics registration via new relic

### DIFF
--- a/core-metrics-newrelic/core.go
+++ b/core-metrics-newrelic/core.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Simfiny Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core_metrics_newrelic
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
+)
+
+// ServiceMetricsEngine encapsulates the registration functionality as well as the facility to emit metrics to
+// the new relic platform for observance
+type ServiceMetricsEngine struct {
+	Havester *telemetry.Harvester
+}
+
+// ServiceMetadata outlines important pieces of information pertaining to the service
+// the data points making up this object should further aid the on-call engineer to
+// properly root cause any ambiguities tied to a ny metrics
+type ServiceMetadata struct {
+	// Name is the service name
+	Name string
+	// The version of the service actively deployed
+	Version string
+	// The service P.O.
+	PointOfContact string
+	// A link to documentation around the service's functionality and uses
+	DocumentationLink string
+	// The environment in which the service is actively running and deployed in
+	Environment string
+}
+
+// NewServiceMetricsEngine returns a new instance of the service metrics engine
+func NewServiceMetricsEngine(licenseKey *string, serviceMetadata *ServiceMetadata) (*ServiceMetricsEngine, error) {
+	if serviceMetadata == nil {
+		return nil, fmt.Errorf("invalid input arguement. service name cannot be nil")
+	}
+
+	if licenseKey == nil {
+		return nil, fmt.Errorf("invalid input argument. licency key cannot be nil")
+	}
+
+	metricCfg := telemetry.ConfigAPIKey(*licenseKey)
+	svcAttr := telemetry.ConfigCommonAttributes(map[string]interface{}{
+		"app.name":             serviceMetadata.Name,
+		"app.version":          serviceMetadata.Version,
+		"app.point-of-contact": serviceMetadata.PointOfContact,
+		"app.docs":             serviceMetadata.DocumentationLink,
+		"app.env":              serviceMetadata.Environment,
+	})
+	errLogAttr := telemetry.ConfigBasicErrorLogger(os.Stderr)
+	debugLogAttr := telemetry.ConfigBasicDebugLogger(os.Stdout)
+
+	h, err := telemetry.NewHarvester(metricCfg, svcAttr, errLogAttr, debugLogAttr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceMetricsEngine{
+		Havester: h,
+	}, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jinzhu/gorm v1.9.16
 	github.com/lib/pq v1.10.4
 	github.com/mwitkow/go-proto-validators v0.3.2
+	github.com/newrelic/newrelic-telemetry-sdk-go v0.8.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mwitkow/go-proto-validators v0.3.2 h1:qRlmpTzm2pstMKKzTdvwPCF5QfBNURSlAgN/R+qbKos=
 github.com/mwitkow/go-proto-validators v0.3.2/go.mod h1:ej0Qp0qMgHN/KtDyUt+Q1/tA7a5VarXUOUxD+oeD30w=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/newrelic/newrelic-telemetry-sdk-go v0.8.1 h1:6OX5VXMuj2salqNBc41eXKz6K+nV6OB/hhlGnAKCbwU=
+github.com/newrelic/newrelic-telemetry-sdk-go v0.8.1/go.mod h1:2kY6OeOxrJ+RIQlVjWDc/pZlT3MIf30prs6drzMfJ6E=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=


### PR DESCRIPTION
Signed-off-by: LensPlatform <yoanyombapro@gmail.com>

This pull request enable metric registration via new-relic. This was needed as all services will require some form of telemetry thus its useful to not reproduce code. Having the registration process live in a single code base is important and protects us again code duplication.